### PR TITLE
restrict file_id in path generation

### DIFF
--- a/lib/etda_utilities/etda_file_paths.rb
+++ b/lib/etda_utilities/etda_file_paths.rb
@@ -35,7 +35,7 @@ module EtdaUtilities
     end
 
     def detailed_file_path(file_id)
-      str1 = format("%02d", ((file_id || 0) % 100))
+      str1 = format("%02d", ((file_id.to_i || 0) % 100))
       str2 = file_id.to_s
       str1 + '/' + str2 + '/'
     end

--- a/spec/lib/etda_utilities_etda_file_paths_spec.rb
+++ b/spec/lib/etda_utilities_etda_file_paths_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe EtdaUtilities::EtdaFilePaths, type: :model do
         id = 19857
         expect(subject.detailed_file_path(id)).to eq('57/19857/')
       end
+      it 'works for a submitted string' do
+        id = "345"
+        expect(subject.detailed_file_path(id)).to eq('45/345/')
+      end
     end
 
     context '#explore_download_file_path' do


### PR DESCRIPTION
the file_id is sometimes being transmitted to the function as a string, sometimes an integer.
By casting to an integer, we ensure that it is formatted properly for the creation
of the file download path.