### PR TITLE
Unblock etda error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    etda_utilities (0.21.1)
+    etda_utilities (0.21.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/etda_utilities/access_levels_for_partners.yml
+++ b/lib/etda_utilities/access_levels_for_partners.yml
@@ -30,6 +30,10 @@ honors:
     restricted_to_institution_attr:
       description_html: 'Access restricted to individuals having a valid Penn State Access Account, for a period of two years. Allows restricted access of the entire work beginning immediately after degree conferral. At the end of the two-year period, the status will automatically change to Open Access. <i>Intended for use by authors in cases where prior public release of the work may compromise its acceptance for publication.</i>'
       scope: final_restricted_institution
+    restricted_liberal_arts: 'Restricted (Liberal Arts Only)'
+    restricted_liberal_arts_attr:
+      description_html: 'Immediately after the conferral of the degree, the abstract becomes accessible worldwide. All other parts of the document are restricted to Penn State only for an embargo period of five (5) years for dissertations from the College of the Liberal Arts. No extensions will be granted beyond five (5) years.'
+      scope: final_restricted_liberal_arts
     restricted: 'Restricted'
     restricted_attr:
       description_html: 'The option selected secures the body of the thesis for a period of two years. Selection of this option requires that an invention disclosure (ID) be filed with the Office of Technology Management (OTM) prior to submission of the final honors thesis and confirmed by OTM. At the end of the two-year period, the work will be released automatically for open access unless a written request is made to extend this option for an additional year. The written request for an extension should be sent 30 days prior to the end of the two-year period to the Honors College Records Department, 10 Schreyer Honors College, The Pennsylvania State University, University Park, PA 16802, or by e-mail to <a href="mailto:SHCAcademics@psu.edu">SHCAcademics@psu.edu</a>. Please note: No one will be able to view your work under this option.'
@@ -48,6 +52,10 @@ milsch:
      restricted_to_institution_attr:
        description_html: 'Access restricted to individuals having a valid Penn State Access Account, for a period of two years. Allows restricted access of the entire work beginning immediately after degree conferral. At the end of the two-year period, the status will automatically change to Open Access. <i>Intended for use by authors in cases where prior public release of the work may compromise its acceptance for publication.</i>'
        scope: final_restricted_institution
+     restricted_liberal_arts: 'Restricted (Liberal Arts Only)'
+     restricted_liberal_arts_attr:
+       description_html: 'Immediately after the conferral of the degree, the abstract becomes accessible worldwide. All other parts of the document are restricted to Penn State only for an embargo period of five (5) years for dissertations from the College of the Liberal Arts. No extensions will be granted beyond five (5) years.'
+       scope: final_restricted_liberal_arts
      restricted: Restricted
      restricted_attr:
        description_html: 'The option selected secures the body of the thesis for a period of two years. Selection of this option requires that an invention disclosure (ID) be filed with the Office of Technology Management (OTM) prior to submission of the final thesis and confirmed by OTM. At the end of the two-year period, the work will be released automatically for open access unless a written request is made to extend this option for an additional year. The written request for an extension should be sent to Millennium Scholars Program, 130 Ritenour Building, University Park, PA 16802 or by email to <a href="mailto:millennium@psu.edu">millennium@psu.edu</a>.  Please note: No one will be able to view your work under this option.'
@@ -66,6 +74,10 @@ sset:
     restricted_to_institution_attr:
       description_html: 'Access restricted to individuals having a valid Penn State Access Account, for a period of two years. Allows restricted access of the entire work beginning immediately after degree conferral. At the end of the two-year period, the status will automatically change to Open Access. <i>Intended for use by authors in cases where prior public release of the work may compromise its acceptance for publication.</i>'
       scope: final_restricted_institution
+    restricted_liberal_arts: 'Restricted (Liberal Arts Only)'
+    restricted_liberal_arts_attr:
+      description_html: 'Immediately after the conferral of the degree, the abstract becomes accessible worldwide. All other parts of the document are restricted to Penn State only for an embargo period of five (5) years for dissertations from the College of the Liberal Arts. No extensions will be granted beyond five (5) years.'
+      scope: final_restricted_liberal_arts
     restricted: Restricted
     restricted_attr:
       description_html: 'Restricts the entire work for the purpose of filing a patent. At the end of the two-year period, the status will automatically change to Open Access. Selection of this option requires that an invention disclosure (ID) be filed with the Office of Technology Management (OTM) prior to submission of the final paper , and confirmed by OTM.  If no Penn State University funds were utilized in this final paper please enter “NOPSUFUNDS”  for the Invention Disclosure Number field below.'

--- a/lib/etda_utilities/etda_file_paths.rb
+++ b/lib/etda_utilities/etda_file_paths.rb
@@ -52,7 +52,7 @@ module EtdaUtilities
 
       return explore_open + detailed_file_path(file_id) + filename if access_level == 'open_access'
 
-      return explore_psu_only + detailed_file_path(file_id) + filename if access_level == 'restricted_to_institution' || access_level == 'restricted_liberal_arts'
+      return explore_psu_only + detailed_file_path(file_id) + filename if ['restricted_to_institution', 'restricted_liberal_arts'].include?(access_level)
 
       nil
     end

--- a/lib/etda_utilities/etda_file_paths.rb
+++ b/lib/etda_utilities/etda_file_paths.rb
@@ -52,9 +52,7 @@ module EtdaUtilities
 
       return explore_open + detailed_file_path(file_id) + filename if access_level == 'open_access'
 
-      return explore_psu_only + detailed_file_path(file_id) + filename if access_level == 'restricted_to_institution'
-
-      return explore_liberal_arts_only + detailed_file_path(file_id) + filename if access_level == 'restricted_liberal_arts'
+      return explore_psu_only + detailed_file_path(file_id) + filename if access_level == 'restricted_to_institution' || access_level == 'restricted_liberal_arts'
 
       nil
     end

--- a/lib/etda_utilities/version.rb
+++ b/lib/etda_utilities/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EtdaUtilities
-  VERSION = "0.21.1"
+  VERSION = "0.21.2"
 end

--- a/spec/lib/etda_utilities_etda_file_paths_spec.rb
+++ b/spec/lib/etda_utilities_etda_file_paths_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe EtdaUtilities::EtdaFilePaths, type: :model do
 
       it 'returns a path for restricted_liberal_arts records' do
         access_level = 'restricted_liberal_arts'
-        expect(subject.explore_download_file_path(file_id, access_level, filename)).to eq('tmp/restricted_liberal_arts/45/345/myfile.pdf')
+        expect(subject.explore_download_file_path(file_id, access_level, filename)).to eq('tmp/restricted_institution/45/345/myfile.pdf')
       end
 
       it 'returns a path for open_access records' do


### PR DESCRIPTION
The other partners are throwing errors with the new embargo option. I think the description, attrs, etc still need to be there for the other partners even if it's not an option for them (looks like the case for restricted_psu_only)

Also corrected the file paths to group restricted_liberal_arts with restricted_psu_only. Fawn doesn't want a facet for restricted_liberal_arts

Bumps version number for new release