### PR TITLE
Add toggle for remediated files to add subdirectory when files are remediated

### DIFF
--- a/lib/etda_utilities/etda_file_paths.rb
+++ b/lib/etda_utilities/etda_file_paths.rb
@@ -39,10 +39,13 @@ module EtdaUtilities
       "#{explore_base_path}#{RESTRICTED_LIBERAL_ARTS_DIR}/"
     end
 
-    def detailed_file_path(file_id)
+    # If remediated is true, the path will include the "remediated" subdirectory
+    # This will differentiate remediated files from original files while
+    # maintaining a similar directory structure to final_submission_files.
+    def detailed_file_path(file_id, remediated: false)
       str1 = format("%02d", ((file_id.to_i || 0) % 100))
       str2 = file_id.to_s
-      "#{str1}/#{str2}/"
+      remediated ? "remediated/#{str1}/#{str2}/" : "#{str1}/#{str2}/"
     end
 
     def explore_download_file_path(file_id, access_level, filename)

--- a/lib/etda_utilities/etda_file_paths.rb
+++ b/lib/etda_utilities/etda_file_paths.rb
@@ -48,14 +48,14 @@ module EtdaUtilities
       remediated ? "remediated/#{str1}/#{str2}/" : "#{str1}/#{str2}/"
     end
 
-    def explore_download_file_path(file_id, access_level, filename)
+    def explore_download_file_path(file_id, access_level, filename, remediated: false)
       return nil if file_id.nil? || access_level.empty?
 
       return nil if access_level == 'restricted'
 
-      return explore_open + detailed_file_path(file_id) + filename if access_level == 'open_access'
+      return explore_open + detailed_file_path(file_id, remediated: remediated) + filename if access_level == 'open_access'
 
-      return explore_psu_only + detailed_file_path(file_id) + filename if ['restricted_to_institution', 'restricted_liberal_arts'].include?(access_level)
+      return explore_psu_only + detailed_file_path(file_id, remediated: remediated) + filename if ['restricted_to_institution', 'restricted_liberal_arts'].include?(access_level)
 
       nil
     end

--- a/spec/lib/etda_utilities_etda_file_paths_spec.rb
+++ b/spec/lib/etda_utilities_etda_file_paths_spec.rb
@@ -65,8 +65,9 @@ RSpec.describe EtdaUtilities::EtdaFilePaths, type: :model do
     end
 
     describe '#explore_download_file_path' do
-      file_id = 345
-      filename = 'myfile.pdf'
+      let(:file_id) { 345 }
+      let(:filename) { 'myfile.pdf' }
+
       it 'is nil for restricted files' do
         access_level = 'restricted'
         expect(subject.explore_download_file_path(file_id, access_level, filename)).to be_nil
@@ -101,6 +102,13 @@ RSpec.describe EtdaUtilities::EtdaFilePaths, type: :model do
         access_level = 'open_access'
         file_id = nil
         expect(subject.explore_download_file_path(file_id, access_level, filename)).to be_nil
+      end
+
+      it 'includes remediated in the path when remediated is true' do
+        access_level = 'open_access'
+        expect(subject.explore_download_file_path(file_id, access_level, filename, remediated: true)).to eq('tmp/open_access/remediated/45/345/myfile.pdf')
+        access_level = 'restricted_to_institution'
+        expect(subject.explore_download_file_path(file_id, access_level, filename, remediated: true)).to eq('tmp/restricted_institution/remediated/45/345/myfile.pdf')
       end
     end
   end

--- a/spec/lib/etda_utilities_etda_file_paths_spec.rb
+++ b/spec/lib/etda_utilities_etda_file_paths_spec.rb
@@ -57,6 +57,11 @@ RSpec.describe EtdaUtilities::EtdaFilePaths, type: :model do
         id = "345"
         expect(subject.detailed_file_path(id)).to eq('45/345/')
       end
+
+      it 'includes remediated in the path when remediated is true' do
+        id = 345
+        expect(subject.detailed_file_path(id, remediated: true)).to eq('remediated/45/345/')
+      end
     end
 
     describe '#explore_download_file_path' do


### PR DESCRIPTION
Part of https://github.com/psu-libraries/etda_workflow/issues/968 . 

This will do most of the heavy lifting to get remediated files in a location similar to regular final submissions files, without conflicts.  It is fully backwards compatible too.  So, these changes will not affect the final submission file locations.

I'll need to publish this to get my changes in Workflow finalized.